### PR TITLE
feat: implement use cases for photo management

### DIFF
--- a/lib/application/photo/results/get_all_photos_result.dart
+++ b/lib/application/photo/results/get_all_photos_result.dart
@@ -1,0 +1,11 @@
+import 'package:geo_snap/domain/entities/photo_entity.dart';
+
+sealed class GetAllPhotosResult {}
+
+final class PhotosFound extends GetAllPhotosResult {
+  final List<PhotoEntity> photos;
+
+  PhotosFound(this.photos);
+}
+
+class NotPhotosFound extends GetAllPhotosResult {}

--- a/lib/application/photo/results/get_photo_by_id_result.dart
+++ b/lib/application/photo/results/get_photo_by_id_result.dart
@@ -1,0 +1,11 @@
+import 'package:geo_snap/domain/entities/photo_entity.dart';
+
+sealed class GetPhotoByIdResult {}
+
+final class PhotoFound extends GetPhotoByIdResult {
+  final PhotoEntity photo;
+
+  PhotoFound(this.photo);
+}
+
+final class PhotoNotFound extends GetPhotoByIdResult {}

--- a/lib/application/photo/results/results.dart
+++ b/lib/application/photo/results/results.dart
@@ -1,0 +1,2 @@
+export 'get_all_photos_result.dart';
+export 'get_photo_by_id_result.dart';

--- a/lib/application/photo/usecases/get_all_photos_usecase.dart
+++ b/lib/application/photo/usecases/get_all_photos_usecase.dart
@@ -1,0 +1,16 @@
+import 'package:geo_snap/domain/repositories/photo_repository.dart';
+import 'package:geo_snap/application/photo/results/get_all_photos_result.dart';
+
+class GetAllPhotosUseCase {
+  final PhotoRepository repository;
+
+  GetAllPhotosUseCase(this.repository);
+
+  Future<GetAllPhotosResult> call() async {
+    final photos = await repository.getAllPhotos();
+    if (photos.isEmpty) {
+      return NotPhotosFound();
+    }
+    return PhotosFound(photos);
+  }
+}

--- a/lib/application/photo/usecases/get_photo_by_id_usecase.dart
+++ b/lib/application/photo/usecases/get_photo_by_id_usecase.dart
@@ -1,0 +1,16 @@
+import 'package:geo_snap/application/photo/results/get_photo_by_id_result.dart';
+import 'package:geo_snap/domain/repositories/photo_repository.dart';
+
+class GetPhotoByIdUseCase {
+  final PhotoRepository repository;
+
+  GetPhotoByIdUseCase(this.repository);
+
+  Future<GetPhotoByIdResult> call(String id) async {
+    final photo = await repository.getPhotoById(id);
+    if (photo == null) {
+      return PhotoNotFound();
+    }
+    return PhotoFound(photo);
+  }
+}

--- a/lib/application/photo/usecases/save_photo_usecase.dart
+++ b/lib/application/photo/usecases/save_photo_usecase.dart
@@ -1,0 +1,12 @@
+import 'package:geo_snap/domain/entities/photo_entity.dart';
+import 'package:geo_snap/domain/repositories/photo_repository.dart';
+
+class SavePhotoUseCase {
+  final PhotoRepository repository;
+
+  SavePhotoUseCase(this.repository);
+
+  Future<void> call(PhotoEntity photo) async {
+    await repository.savePhoto(photo);
+  }
+} 

--- a/lib/application/photo/usecases/usecases.dart
+++ b/lib/application/photo/usecases/usecases.dart
@@ -1,0 +1,3 @@
+export 'get_all_photos_usecase.dart';
+export 'get_photo_by_id_usecase.dart';
+export 'save_photo_usecase.dart';

--- a/lib/core/services/services.dart
+++ b/lib/core/services/services.dart
@@ -1,0 +1,4 @@
+export 'camera_service.dart';
+export 'location_service.dart';
+export 'navigation_service.dart';
+export 'permission_service.dart';

--- a/lib/di/injection.dart
+++ b/lib/di/injection.dart
@@ -1,11 +1,10 @@
 import 'package:get_it/get_it.dart';
 
-import 'package:geo_snap/core/services/camera_service.dart';
-import 'package:geo_snap/core/services/location_service.dart';
-import 'package:geo_snap/core/services/permission_service.dart';
+import 'package:geo_snap/core/services/services.dart';
 import 'package:geo_snap/data/local/database/daos/photo_dao.dart';
 import 'package:geo_snap/data/datasources/photo_data_source.dart';
 import 'package:geo_snap/presentation/blocs/photo/photo_bloc.dart';
+import 'package:geo_snap/application/photo/usecases/usecases.dart';
 import 'package:geo_snap/domain/repositories/photo_repository.dart';
 import 'package:geo_snap/data/local/database/geo_snap_database.dart';
 import 'package:geo_snap/presentation/blocs/camera/camera_bloc.dart';
@@ -28,9 +27,18 @@ Future<void> setupLocator() async {
   sl.registerLazySingleton(() => CameraService(sl()));
   sl.registerLazySingleton(() => LocationService(sl()));
 
+  // UseCases
+  sl.registerLazySingleton(() => GetAllPhotosUseCase(sl()));
+  sl.registerLazySingleton(() => GetPhotoByIdUseCase(sl()));
+  sl.registerLazySingleton(() => SavePhotoUseCase(sl()));
+
   // Blocs
   sl.registerFactory(
     () => CameraBloc(cameraService: sl(), locationService: sl()),
   );
-  sl.registerFactory(() => PhotoBloc(photoRepository: sl()));
+  sl.registerFactory(() => PhotoBloc(
+    savePhotoUseCase: sl(),
+    getAllPhotosUseCase: sl(),
+    getPhotoByIdUseCase: sl(),
+  ));
 }

--- a/lib/domain/entities/entities.dart
+++ b/lib/domain/entities/entities.dart
@@ -1,0 +1,1 @@
+export 'photo_entity.dart';

--- a/lib/presentation/blocs/camera/camera_bloc.dart
+++ b/lib/presentation/blocs/camera/camera_bloc.dart
@@ -3,8 +3,7 @@ import 'package:equatable/equatable.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-import 'package:geo_snap/core/services/camera_service.dart';
-import 'package:geo_snap/core/services/location_service.dart';
+import 'package:geo_snap/core/services/services.dart';
 
 part 'camera_event.dart';
 part 'camera_state.dart';

--- a/lib/presentation/pages/cameras/photo_preview_page.dart
+++ b/lib/presentation/pages/cameras/photo_preview_page.dart
@@ -5,7 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:geo_snap/config/route_constants.dart';
-import 'package:geo_snap/domain/entities/photo_entity.dart';
+import 'package:geo_snap/domain/entities/entities.dart';
 import 'package:geo_snap/core/services/navigation_service.dart';
 import 'package:geo_snap/presentation/blocs/photo/photo_bloc.dart';
 import 'package:geo_snap/presentation/models/photo_preview_data.dart';


### PR DESCRIPTION
- The `GetAllPhotosUseCase`, `GetPhotoByIdUseCase` and `SavePhotoUseCase` use cases were added to handle photo fetching and saving.
- Created `GetAllPhotosResult` and `GetPhotoByIdResult` result classes to handle operation responses.
- Updated the `PhotoBloc` to use the new use cases instead of the repository directly.
- Organized the export of results and use cases in their respective files.